### PR TITLE
LFLT-328 Add option to provide custom header parameters for Bridge

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/hu/psprog/leaflet/bridge/client/domain/BridgeConstants.java
+++ b/api/src/main/java/hu/psprog/leaflet/bridge/client/domain/BridgeConstants.java
@@ -10,4 +10,5 @@ public class BridgeConstants {
     public static final String DEVICE_ID_HEADER = "X-Device-ID";
     public static final String CLIENT_ID_HEADER = "X-Client-ID";
     public static final String AUTH_TOKEN_HEADER = "X-Auth-Token";
+    public static final String X_CAPTCHA_RESPONSE = "X-Captcha-Response";
 }

--- a/api/src/main/java/hu/psprog/leaflet/bridge/client/request/RESTRequest.java
+++ b/api/src/main/java/hu/psprog/leaflet/bridge/client/request/RESTRequest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static hu.psprog.leaflet.bridge.client.domain.BridgeConstants.X_CAPTCHA_RESPONSE;
+
 /**
  * Model object containing all necessary information of a request.
  *
@@ -21,6 +23,7 @@ public class RESTRequest {
     private Serializable requestBody;
     private Map<String, Object> pathParameters = new HashMap<>();
     private Map<String, Object> requestParameters = new HashMap<>();
+    private Map<String, Object> headerParameters = new HashMap<>();
     private boolean multipart;
     private RequestBodyAdapter adapter;
 
@@ -50,6 +53,10 @@ public class RESTRequest {
 
     public Map<String, Object> getRequestParameters() {
         return requestParameters;
+    }
+
+    public Map<String, Object> getHeaderParameters() {
+        return headerParameters;
     }
 
     public boolean isMultipart() {
@@ -174,6 +181,31 @@ public class RESTRequest {
         public RESTRequestBuilder addRequestParameters(String key, String value) {
             restRequest.requestParameters.put(key, value);
             return this;
+        }
+
+        /**
+         * _Optional_
+         * Adds a header parameter to the request.
+         *
+         * @param key key of the header parameter
+         * @param value oncrete value of the header parameter
+         * @return Builder instance
+         */
+        public RESTRequestBuilder addHeaderParameter(String key, String value) {
+            restRequest.headerParameters.put(key, value);
+            return this;
+        }
+
+        /**
+         * _Optional_
+         * Adds ReCaptcha response token to the request as X-Captcha-Response header parameter.
+         * Mandatory for ReCaptcha-validated requests!
+         *
+         * @param value ReCaptcha response token
+         * @return Builder instance
+         */
+        public RESTRequestBuilder recaptchaResponse(String value) {
+            return addHeaderParameter(X_CAPTCHA_RESPONSE, value);
         }
 
         /**

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/impl/src/main/java/hu/psprog/leaflet/bridge/client/impl/InvocationFactoryImpl.java
+++ b/impl/src/main/java/hu/psprog/leaflet/bridge/client/impl/InvocationFactoryImpl.java
@@ -47,6 +47,7 @@ public class InvocationFactoryImpl implements InvocationFactory {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .header(DEVICE_ID_HEADER, requestAdapter.provideDeviceID())
                 .header(CLIENT_ID_HEADER, requestAdapter.provideClientID());
+        addCustomHeaderParameters(builder, restRequest);
         authenticate(builder, restRequest);
 
         return callStrategyMap
@@ -62,6 +63,11 @@ public class InvocationFactoryImpl implements InvocationFactory {
         }
 
         return targetWithParameters;
+    }
+
+    private void addCustomHeaderParameters(Invocation.Builder builder, RESTRequest request) {
+        request.getHeaderParameters()
+                .forEach(builder::header);
     }
 
     private void authenticate(Invocation.Builder builder, RESTRequest request) {

--- a/impl/src/test/java/hu/psprog/leaflet/bridge/client/impl/InvocationFactoryImplTest.java
+++ b/impl/src/test/java/hu/psprog/leaflet/bridge/client/impl/InvocationFactoryImplTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 
 import static hu.psprog.leaflet.bridge.client.domain.BridgeConstants.CLIENT_ID_HEADER;
 import static hu.psprog.leaflet.bridge.client.domain.BridgeConstants.DEVICE_ID_HEADER;
+import static hu.psprog.leaflet.bridge.client.domain.BridgeConstants.X_CAPTCHA_RESPONSE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -70,6 +71,7 @@ public class InvocationFactoryImplTest {
     private static final String PARAMETER_LIST = "parameterList";
     private static final List<String> VALUE_LIST = Arrays.asList("param1", "param2", "param3");
     private static final String GENERATED_QUERY_FOR_MULTI_PARAMETER_REQUEST = "parameterList=param1,param2,param3";
+    private static final String RECAPTCHA_TOKEN = "recaptcha-token";
     private static final WebTarget WEB_TARGET = ClientBuilder.newBuilder()
             .build()
             .target(TARGET);
@@ -145,7 +147,7 @@ public class InvocationFactoryImplTest {
     }
 
     @Test
-    public void shouldGetInvocationForAuthenticatedPost() throws JsonProcessingException {
+    public void shouldGetInvocationForAuthenticatedAndReCaptchaValidatedPost() throws JsonProcessingException {
 
         // given
         EntryCreateRequestModel entryCreateRequestModel = new EntryCreateRequestModel();
@@ -154,6 +156,7 @@ public class InvocationFactoryImplTest {
                 .path(TestPath.ENTRIES)
                 .requestBody(entryCreateRequestModel)
                 .authenticated()
+                .recaptchaResponse(RECAPTCHA_TOKEN)
                 .build();
 
         // when
@@ -168,6 +171,7 @@ public class InvocationFactoryImplTest {
         assertThat(clientRequest.getEntity(), equalTo(entryCreateRequestModel));
         assertThat(clientRequest.getHeaderString(AUTHORIZATION), equalTo(BEARER_TOKEN));
         assertThat(clientRequest.getHeaderString(DEVICE_ID_HEADER), equalTo(DEVICE_ID));
+        assertThat(clientRequest.getHeaderString(X_CAPTCHA_RESPONSE), equalTo(RECAPTCHA_TOKEN));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-bridge</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 
     <modules>
         <module>api</module>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - RESTRequest class is extended with methods to add header parameters and explicitly recaptcha response value
 - InvocationFactory aligned to add header parameters to the request
 - Tests aligned