### PR TITLE
LFLT-480 Update dependencies of Leaflet stack components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build_leaflet-bridge:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oauth-support/pom.xml
+++ b/oauth-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <artifactId>leaflet-bridge</artifactId>
     <packaging>pom</packaging>
-    <version>3.3.0</version>
+    <version>3.3.1</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>1.0-r2110.1</version>
+        <version>2.0-r2208.1</version>
     </parent>
 
     <modules>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Changed CircleCI build image version
 - Updated Leaflet Stack Base BOM version to 2.0-r2208.1
 - Bumped version to 3.3.1