### PR TITLE
LFLT-511 Make adding the client and device ID header configurable in Bridge

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/hu/psprog/leaflet/bridge/client/domain/BridgeSettings.java
+++ b/api/src/main/java/hu/psprog/leaflet/bridge/client/domain/BridgeSettings.java
@@ -14,6 +14,7 @@ public class BridgeSettings {
     
     private String hostUrl;
     private String oAuthRegistrationID;
+    private boolean useLeafletLink = true;
 
     public String getHostUrl() {
         return hostUrl;
@@ -31,6 +32,14 @@ public class BridgeSettings {
         this.oAuthRegistrationID = oAuthRegistrationID;
     }
 
+    public boolean isUseLeafletLink() {
+        return useLeafletLink;
+    }
+
+    void setUseLeafletLink(boolean useLeafletLink) {
+        this.useLeafletLink = useLeafletLink;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -42,6 +51,7 @@ public class BridgeSettings {
         return new EqualsBuilder()
                 .append(hostUrl, that.hostUrl)
                 .append(oAuthRegistrationID, that.oAuthRegistrationID)
+                .append(useLeafletLink, that.useLeafletLink)
                 .isEquals();
     }
 
@@ -50,6 +60,7 @@ public class BridgeSettings {
         return new HashCodeBuilder(17, 37)
                 .append(hostUrl)
                 .append(oAuthRegistrationID)
+                .append(useLeafletLink)
                 .toHashCode();
     }
 
@@ -58,6 +69,7 @@ public class BridgeSettings {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("hostUrl", hostUrl)
                 .append("oAuthRegistrationID", oAuthRegistrationID)
+                .append("useLeafletLink", useLeafletLink)
                 .toString();
     }
 
@@ -71,6 +83,7 @@ public class BridgeSettings {
     public static final class BridgeSettingsBuilder {
         private String hostUrl;
         private String oAuthRegistrationID;
+        private boolean useLeafletLink;
 
         private BridgeSettingsBuilder() {
         }
@@ -85,10 +98,16 @@ public class BridgeSettings {
             return this;
         }
 
+        public BridgeSettingsBuilder withUseLeafletLink(boolean useLeafletLink) {
+            this.useLeafletLink = useLeafletLink;
+            return this;
+        }
+
         public BridgeSettings build() {
             BridgeSettings bridgeSettings = new BridgeSettings();
             bridgeSettings.hostUrl = this.hostUrl;
             bridgeSettings.oAuthRegistrationID = this.oAuthRegistrationID;
+            bridgeSettings.useLeafletLink = this.useLeafletLink;
             return bridgeSettings;
         }
     }

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/oauth-support/pom.xml
+++ b/oauth-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,6 +15,10 @@
         <dependency>
             <groupId>hu.psprog.leaflet</groupId>
             <artifactId>bridge-implementation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>bridge-spring-integration</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/oauth-support/src/main/java/hu/psprog/leaflet/bridge/oauth/support/SpringIntegratedOAuthRequestAuthentication.java
+++ b/oauth-support/src/main/java/hu/psprog/leaflet/bridge/oauth/support/SpringIntegratedOAuthRequestAuthentication.java
@@ -8,10 +8,12 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.core.AbstractOAuth2Token;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -55,10 +57,15 @@ public class SpringIntegratedOAuthRequestAuthentication implements RequestAuthen
 
     private OAuth2AuthorizeRequest createAuthorizeRequest() {
 
-        return OAuth2AuthorizeRequest
-                .withClientRegistrationId(registrationID)
-                .principal(SecurityContextHolder.getContext().getAuthentication())
-                .build();
+        OAuth2AuthorizeRequest.Builder builder = OAuth2AuthorizeRequest.withClientRegistrationId(registrationID);
+
+        if (Objects.isNull(RequestContextHolder.getRequestAttributes())) {
+            builder.principal(registrationID);
+        } else {
+            builder.principal(SecurityContextHolder.getContext().getAuthentication());
+        }
+
+        return builder.build();
     }
 
     private Map<String, String> formatAuthorizationHeader(String accessToken) {

--- a/oauth-support/src/test/java/hu/psprog/leaflet/bridge/oauth/support/SpringIntegratedOAuthRequestAuthenticationTest.java
+++ b/oauth-support/src/test/java/hu/psprog/leaflet/bridge/oauth/support/SpringIntegratedOAuthRequestAuthenticationTest.java
@@ -7,18 +7,22 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -47,6 +51,9 @@ class SpringIntegratedOAuthRequestAuthenticationTest {
     @Mock
     private OAuth2AccessToken accessToken;
 
+    @Mock
+    private RequestAttributes requestAttributes;
+
     @Captor
     private ArgumentCaptor<OAuth2AuthorizeRequest> authorizeRequestCaptor;
 
@@ -58,10 +65,12 @@ class SpringIntegratedOAuthRequestAuthenticationTest {
     }
 
     @Test
-    public void shouldGetAuthenticationHeaderRequestTokenFromClientManager() {
+    public void shouldGetAuthenticationHeaderRequestTokenFromClientManagerForWebRequest() {
 
         // given
         SecurityContextHolder.getContext().setAuthentication(authentication);
+        RequestContextHolder.setRequestAttributes(requestAttributes);
+
         given(clientManager.authorize(any(OAuth2AuthorizeRequest.class))).willReturn(authorizedClient);
         given(authorizedClient.getAccessToken()).willReturn(accessToken);
         given(accessToken.getTokenValue()).willReturn(ACCESS_TOKEN_VALUE);
@@ -79,6 +88,29 @@ class SpringIntegratedOAuthRequestAuthenticationTest {
         assertThat(capturedAuthorizeRequest.getPrincipal(), equalTo(authentication));
 
         SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void shouldGetAuthenticationHeaderRequestTokenFromClientManagerForBackgroundRequest() {
+
+        // given
+        given(clientManager.authorize(any(OAuth2AuthorizeRequest.class))).willReturn(authorizedClient);
+        given(authorizedClient.getAccessToken()).willReturn(accessToken);
+        given(accessToken.getTokenValue()).willReturn(ACCESS_TOKEN_VALUE);
+
+        // when
+        Map<String, String> result = springIntegratedOAuthRequestAuthentication.getAuthenticationHeader();
+
+        // then
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get("Authorization"), equalTo(ACCESS_TOKEN_BEARER));
+
+        verify(clientManager).authorize(authorizeRequestCaptor.capture());
+        OAuth2AuthorizeRequest capturedAuthorizeRequest = authorizeRequestCaptor.getValue();
+        assertThat(capturedAuthorizeRequest.getClientRegistrationId(), equalTo(REGISTRATION_ID));
+        assertThat(capturedAuthorizeRequest.getPrincipal(), isA(AbstractAuthenticationToken.class));
+        assertThat(capturedAuthorizeRequest.getPrincipal().getPrincipal(), equalTo(REGISTRATION_ID));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-bridge</artifactId>
     <packaging>pom</packaging>
-    <version>3.3.1</version>
+    <version>3.4.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
@@ -25,6 +25,9 @@
 
         <!-- Java environment version -->
         <java.version>11</java.version>
+
+        <!-- overrides for leaflet internal libs -->
+        <leaflet.bridge.version>${project.version}</leaflet.bridge.version>
 
         <!-- compiler settings -->
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-integration/src/main/java/hu/psprog/leaflet/bridge/integration/request/adapter/StaticRequestAdapter.java
+++ b/spring-integration/src/main/java/hu/psprog/leaflet/bridge/integration/request/adapter/StaticRequestAdapter.java
@@ -1,0 +1,38 @@
+package hu.psprog.leaflet.bridge.integration.request.adapter;
+
+import hu.psprog.leaflet.bridge.client.request.RequestAdapter;
+
+import java.util.UUID;
+
+/**
+ * {@link RequestAdapter} implementation for services not using Leaflet-Link identification.
+ * The client ID will always the registration ID of the Bridge client, and the device ID is a random UUID generated
+ * on instantiation. Access token consumption is not supported.
+ *
+ * @author Peter Smith
+ */
+public class StaticRequestAdapter implements RequestAdapter {
+
+    private final String deviceID;
+    private final String clientID;
+
+    public StaticRequestAdapter(String clientID) {
+        this.deviceID = UUID.randomUUID().toString();
+        this.clientID = clientID;
+    }
+
+    @Override
+    public String provideDeviceID() {
+        return deviceID;
+    }
+
+    @Override
+    public String provideClientID() {
+        return clientID;
+    }
+
+    @Override
+    public void consumeAuthenticationToken(String token) {
+        throw new UnsupportedOperationException("Static request adapter implementation does not support consuming the auth token");
+    }
+}

--- a/spring-integration/src/test/java/hu/psprog/leaflet/bridge/integration/request/adapter/StaticRequestAdapterTest.java
+++ b/spring-integration/src/test/java/hu/psprog/leaflet/bridge/integration/request/adapter/StaticRequestAdapterTest.java
@@ -1,0 +1,54 @@
+package hu.psprog.leaflet.bridge.integration.request.adapter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link StaticRequestAdapter}.
+ *
+ * @author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+class StaticRequestAdapterTest {
+
+    private static final String CLIENT_ID = "client1";
+
+    private final StaticRequestAdapter staticRequestAdapter = new StaticRequestAdapter(CLIENT_ID);
+
+    @Test
+    public void shouldProvideDeviceIDReturnARandomUUID() {
+
+        // when
+        String result = staticRequestAdapter.provideDeviceID();
+
+        // then
+        UUID.fromString(result);
+    }
+
+    @Test
+    public void shouldProvideClientIDReturnTheRegisteredClientID() {
+
+        // when
+        String result = staticRequestAdapter.provideClientID();
+
+        // then
+        assertThat(result, equalTo(CLIENT_ID));
+    }
+
+    @Test
+    public void shouldConsumeAuthenticationTokenThrowException() {
+
+        // when
+        assertThrows(UnsupportedOperationException.class, () -> staticRequestAdapter.consumeAuthenticationToken("token"));
+
+        // then
+        // exception expected
+    }
+}


### PR DESCRIPTION
 - Made Leaflet-Link compliant RequestAdapter usage optional
 - Aligned creating OAuth authorization request for background usages
 - Aligned existing, added new tests
 - Bumped library version to 3.4.0