### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/impl/src/main/java/hu/psprog/leaflet/bridge/client/impl/BridgeClientImpl.java
+++ b/impl/src/main/java/hu/psprog/leaflet/bridge/client/impl/BridgeClientImpl.java
@@ -3,6 +3,8 @@ package hu.psprog.leaflet.bridge.client.impl;
 import hu.psprog.leaflet.bridge.client.BridgeClient;
 import hu.psprog.leaflet.bridge.client.domain.BridgeSettings;
 import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.DefaultNonSuccessfulResponseException;
+import hu.psprog.leaflet.bridge.client.exception.ValidationFailureException;
 import hu.psprog.leaflet.bridge.client.handler.InvocationFactory;
 import hu.psprog.leaflet.bridge.client.handler.ResponseReader;
 import hu.psprog.leaflet.bridge.client.request.RESTRequest;
@@ -73,6 +75,9 @@ public class BridgeClientImpl implements BridgeClient {
 
         try {
             return callSupplier.get();
+
+        } catch (ValidationFailureException | DefaultNonSuccessfulResponseException exception) {
+            throw exception;
 
         } catch (Exception exception) {
 

--- a/impl/src/test/java/hu/psprog/leaflet/bridge/client/impl/BridgeClientImplTest.java
+++ b/impl/src/test/java/hu/psprog/leaflet/bridge/client/impl/BridgeClientImplTest.java
@@ -4,6 +4,7 @@ import hu.psprog.leaflet.api.rest.response.common.WrapperBodyDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.EntryDataModel;
 import hu.psprog.leaflet.bridge.client.domain.BridgeSettings;
 import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.ResourceNotFoundException;
 import hu.psprog.leaflet.bridge.client.request.RESTRequest;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -192,6 +193,28 @@ public class BridgeClientImplTest {
 
         // when
         assertThrows(CommunicationFailureException.class, () -> {
+            bridgeClient.call(REST_REQUEST);
+            nullResponseCaptor.getValue().handleResponse(classicHttpResponse);
+        });
+
+        // then
+        // expected exception
+    }
+
+    @Test
+    public void shouldThrowKnownExceptionOnCallForWrappedResponse() throws IOException {
+
+        // given
+        given(invocationFactory.getInvocationFor(HOST_URL, REST_REQUEST)).willReturn(classicHttpRequest);
+        doThrow(ResourceNotFoundException.class).when(responseReader).read(classicHttpResponse);
+        doAnswer(invocation -> {
+            var handler = invocation.getArgument(1, HttpClientResponseHandler.class);
+            handler.handleResponse(classicHttpResponse);
+            return null;
+        }).when(httpClient).execute(eq(classicHttpRequest), nullResponseCaptor.capture());
+
+        // when
+        assertThrows(ResourceNotFoundException.class, () -> {
             bridgeClient.call(REST_REQUEST);
             nullResponseCaptor.getValue().handleResponse(classicHttpResponse);
         });

--- a/oauth-support/pom.xml
+++ b/oauth-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <artifactId>leaflet-bridge</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>6.0-r2604.1</version>
+        <version>6.0-r2604.2</version>
     </parent>
 
     <modules>

--- a/spring-integration/pom.xml
+++ b/spring-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-bridge</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.2
 - Fixed fallthrough of identified exceptions in Bridge Implementation
 - Bumped library version to 4.0.1